### PR TITLE
Feat: Implement language-prefixed URLs

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -25,7 +25,7 @@
         {% for analysis in recent_analyses %}
             {% if analysis.video_title != 'Title Not Found' %}
             <div class="feed-item" data-timestamp="{{ analysis.created_at }}">
-                <a href="/report/{{ analysis.id }}" class="feed-item-link">
+                <a href="{{ url_for('serve_report', lang_code=CURRENT_LANG, analysis_id=analysis.id) }}" class="feed-item-link">
                     {% if analysis.input_type == 'text' %}
                         <img src="{{ url_for('static', filename='text-placeholder.png') }}" alt="Text Analysis" class="feed-thumbnail">
                     {% elif analysis.input_type == 'url' %}

--- a/backend/templates/layout.html
+++ b/backend/templates/layout.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{{ _('AI Fact Checker') }}{% endblock %}</title>
+
+    {# Hreflang tags #}
+    {% if request.endpoint and request.endpoint not in ['static', 'set_language'] %} {# Avoid for non-content views #}
+        {% for lang_code_loop in LANGUAGES.keys() %}
+            <link rel="alternate" hreflang="{{ lang_code_loop }}" href="{{ url_for(request.endpoint, lang_code=lang_code_loop, **(request.view_args or {})) }}">
+        {% endfor %}
+        <link rel="alternate" hreflang="x-default" href="{{ url_for(request.endpoint, lang_code='en', **(request.view_args or {})) }}">
+    {% endif %}
+
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 </head>
@@ -20,7 +29,8 @@
             </div>
             <div class="lang-dropdown">
                 {% for lang_code, lang_info in LANGUAGES.items() %}
-                    <a href="{{ url_for('set_language', lang=lang_code) }}" class="lang-option {% if lang_code == CURRENT_LANG %}active{% endif %}">
+                    {# The route expects 'target_lang_code' as the parameter name #}
+                    <a href="{{ url_for('set_language', target_lang_code=lang_code) }}" class="lang-option {% if lang_code == CURRENT_LANG %}active{% endif %}">
                         <span>{{ lang_info['flag'] }}</span>
                         <span>{{ lang_info['name'] }}</span>
                     </a>


### PR DESCRIPTION
This change modifies the routing and URL generation to use language-prefixed URLs (e.g., /en/, /ru/report/xyz) for all content pages to improve SEO and user experience for different languages.

Key changes:
- Root URL ('/') now detects user's preferred language (cookie, then browser, then 'en' default) and redirects to the corresponding prefixed homepage (e.g., '/en/').
- All content routes (homepage, report pages) now require a language code prefix in the URL (e.g., '/<lang_code>/', '/<lang_code>/report/<analysis_id>').
- Updated get_locale() to prioritize lang_code from URL view arguments.
- Updated url_for() calls in templates and Python to generate prefixed URLs, using CURRENT_LANG from the context.
- Modified the set_language route to set the language cookie and redirect to the equivalent page with the new language prefix.
- Implemented hreflang alternate tags in layout.html for all supported languages and an x-default tag.
- Added 301 redirects for old non-prefixed report URLs to their new language-prefixed versions.
- API and static asset routes remain un-prefixed.

This provides a clear, language-specific URL structure for all content. Thorough testing of redirection, language switching, and link generation is recommended.