### PR TITLE
fix: Correct trailing slash in root redirect for language prefix

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -119,8 +119,12 @@ def global_before_request_handler():
 
         current_path = request.path
         if current_path == '/':
-            new_path = f"/{preferred_lang_for_redirect}"
+            new_path = f"/{preferred_lang_for_redirect}/" # Ensure trailing slash to match serve_index route
         else:
+            # For other paths, ensure consistency.
+            # If the target route (e.g. serve_report) is defined without a trailing slash, this is fine.
+            # If it's defined WITH a trailing slash, this might need adjustment or rely on Flask's strict_slashes.
+            # Current serve_report: /<string:lang>/report/<analysis_id> (no trailing slash), so this is okay.
             new_path = f"/{preferred_lang_for_redirect}{current_path}"
 
         if request.query_string:


### PR DESCRIPTION
The redirect from the root path ('/') to a language-prefixed homepage (e.g., '/en/') was missing a trailing slash. This caused a 404 error because the `serve_index` route is defined with a trailing slash (e.g., '/<lang>/').

This commit adds the trailing slash to the redirect path in the `global_before_request_handler` to ensure it correctly matches the `serve_index` route definition.